### PR TITLE
Allow seconds(50) syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,31 @@ The `timeliterals` module is a simple module containing literals
 * `seconds`
 * `milliseconds`
 * `microseconds`
+* `days`
+* `weeks`
 
-Can be used as
+Can be used as a scalar or a function, for example `timedelta(seconds=5)` can be replaced by `seconds(5)` or `5 * seconds`.
 
 ```python
 from timeliterals import *
-delta = 2 * hours - 14 * minutes + 10 * seconds
-delta += 140 * milliseconds - 3 * microseconds
-assert delta < 2 * hours
+duration = 2 * hours - 14 * minutes  # timedelta
+duration += minutes(2)  # function
+assert 1 * hours + 30 * minutes < duration < 2 * hours
+assert duration / minutes == 108
+assert duration / seconds == 6480
+assert duration.total_seconds() == 6480
 ```
 
 ```python
-from timeliterals import hours as h, minutes as m
-delta = 2*h - 14*m
-assert 1*h+30*m < delta < 2 * hours
-assert delta.total_seconds() == 6360
+from timeliterals import *
+from datetime import timedelta
+assert hours(2) == timedelta(hours=2)
+```
+
+```python
+from timeliterals import hours as m, minutes as m, seconds as s, milliseconds as ms, microseconds as us
+duration = 2*h - 14*m + 10*s + 140*ms - 3*us
+assert duration < 2*h
 ```
 
 ## history

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,10 @@ setup(
     packages=[
         'timeliterals',
     ],
-    version='0.0.3',
+    version='0.0.4',
     author='pgdr',
     author_email='pgdr@equinor.com',
     description="Time literals",
     test_suite="tests",
+    url='https://github.com/pgdr/timeliterals',
 )

--- a/tests/test_literals.py
+++ b/tests/test_literals.py
@@ -21,6 +21,11 @@ class TestLiterals(unittest.TestCase):
         import timeliterals as t
         delta = 3*t.hours + 18*t.minutes
         self.assertEqual(delta.total_seconds(), 11880)
+    
+    def test_function(self):
+        from datetime import timedelta
+        self.assertEqual(timedelta(hours=5), hours(5))
+        self.assertTrue(isinstance(hours, timedelta))
 
 if __name__ == '__main__':
     unittest.main()

--- a/timeliterals/__init__.py
+++ b/timeliterals/__init__.py
@@ -1,11 +1,20 @@
-from datetime import timedelta as D
+"""
+>>> from timeliterals import hours
+>>> hours(5)
+datetime.timedelta(0, 18000)
+>>> 5 * hours + 2 * seconds
+datetime.timedelta(0, 18002)
+"""
 
-days = D(days=1)
-hours = D(hours=1)
-minutes = D(minutes=1)
-seconds = D(seconds=1)
-milliseconds = D(milliseconds=1)
-microseconds = D(microseconds=1)
+__all__ = ('seconds', 'milliseconds', 'microseconds', 'weeks', 'days', 'hours', 'minutes')
+__version__ = '0.0.4'
 
-__all__ = ['days', 'hours', 'minutes', 'seconds', 'milliseconds', 'microseconds']
-__version__ = '0.0.3'
+from datetime import timedelta
+
+class CallableTimedelta(timedelta):
+    def __call__(self, x):
+        return self * x
+    
+seconds, milliseconds, microseconds, weeks, days, hours, minutes = (
+    CallableTimedelta(**{x:1})
+    for x in __all__)


### PR DESCRIPTION
Projects using `timedelta(seconds=5)` now have the options to switch to `seconds(5)` to keep the function call syntax, some users might find it more clear.